### PR TITLE
upgrading to Arnft 0.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "http://kalwalt.github.io/ARnft-ES6-react",
   "name": "ARnft-ES6-react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "devDependencies": {
     "@kalwalt/ar-nft": "^0.8.6",
     "gh-pages": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "name": "ARnft-ES6-react",
   "version": "0.1.7",
   "devDependencies": {
-    "@kalwalt/ar-nft": "^0.8.4",
+    "@kalwalt/ar-nft": "^0.8.6",
     "gh-pages": "^3.1.0",
-    "three": "^0.125.0"
+    "three": "^0.127.0"
   },
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.6",

--- a/public/config.json
+++ b/public/config.json
@@ -1,6 +1,11 @@
 {
   "addPath": "ARnft-ES6-react",
   "cameraPara": "Data/camera_para.dat",
+  "container": {
+    "create": true,
+    "containerName": "",
+    "canvasName": ""
+  },
   "videoSettings": {
     "width": {
       "min": 640,
@@ -13,6 +18,7 @@
     "facingMode": "environment"
   },
   "loading": {
+    "create": true,
     "logo": {
       "src": "arNFT-logo.gif",
       "alt": "arNFT.js logo"
@@ -24,5 +30,7 @@
     "alpha": true,
     "antialias": true,
     "precision": "mediump"
+  },
+  "stats": {
+    "createHtml": true
   }
-}

--- a/public/config.json
+++ b/public/config.json
@@ -34,3 +34,4 @@
   "stats": {
     "createHtml": true
   }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,6 +1215,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.10":
+  version "7.13.16"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.16.tgz#673e7b84c1f6287d96d483fa65cd3db792d53e22"
+  integrity sha512-7VsWJsI5USRhBLE/3of+VU2DDNWtYHQlq2IHu2iL15+Yx4qVqP8KllR6JMHQlTKWRyDk9Tw6unkqSusaHXt//A==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.0.tgz#337eda67401f5b066a6f205a3113d4ac18ba495b"
@@ -1570,22 +1577,22 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@kalwalt/ar-nft@^0.8.4":
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/@kalwalt/ar-nft/-/ar-nft-0.8.4.tgz#63d12c067809c4c8f66a2449206ca66ecd71dbc7"
-  integrity sha512-+NgQ/1Xn7B9Tv+weO7/M/accvxsChTBppWmHU9gy68WzFy0tiGA/caN1E2hZiZAe7HNU+s/oGjnCADOwTQHZTA==
+"@kalwalt/ar-nft@^0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@kalwalt/ar-nft/-/ar-nft-0.8.6.tgz#51db5e9c5904258c47f74cd55992618d108df2ae"
+  integrity sha512-nWeEs2e3UUA6p1Lh/BUUtgcD1v+J5BA5dpXumBVVu6k3YCvz9jhH+fRMaglluynRu5BTmD8PZ1BsFnM3mUDLFA==
   dependencies:
-    "@kalwalt/jsartoolkit-nft" "^0.8.2"
+    "@kalwalt/jsartoolkit-nft" "^0.9.1"
     http-server "^0.12.3"
-    terser-webpack-plugin "^5.0.3"
+    terser-webpack-plugin "^5.1.1"
 
-"@kalwalt/jsartoolkit-nft@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@kalwalt/jsartoolkit-nft/-/jsartoolkit-nft-0.8.2.tgz#51e1add82d6a4c87f1ced36a6096e34a94bd5361"
-  integrity sha512-Au8PTTlzVpMi7hKqaOE0thq01SRDZP7CuWXj+U+iGWwO3mGp8LDYHjD8SOwXB+b+/tV32UFPYZLs4pUExqO97w==
+"@kalwalt/jsartoolkit-nft@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@kalwalt/jsartoolkit-nft/-/jsartoolkit-nft-0.9.1.tgz#d59747a11decb0bfe083f5147fd75e018c5569c4"
+  integrity sha512-ZW0ZmkkE2tOXIZhdNvOCMFHmoyeUotS4KFUcxiQxt9FtMUBS5nkGb+uTvqqXW5J8+CstdUkOHQgrVaIW0B0JVw==
   dependencies:
-    "@babel/runtime" "^7.12.5"
-    axios "^0.21.0"
+    "@babel/runtime" "^7.13.10"
+    axios "^0.21.1"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -2734,10 +2741,10 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.2.tgz#c7cf7378378a51fcd272d3c09668002a4990b1cb"
   integrity sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==
 
-axios@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
-  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
 
@@ -7014,15 +7021,6 @@ jest-worker@^26.5.0, jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest-worker@^26.6.1:
-  version "26.6.1"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.1.tgz#c2ae8cde6802cc14056043f997469ec170d9c32a"
-  integrity sha512-R5IE3qSGz+QynJx8y+ICEkdI2OJ3RJjRQVEyCcFAd3yVhQSEtquziPO29Mlzgn07LOVE8u8jhJ1FqcwegiXWOw==
-  dependencies:
-    "@types/node" "*"
-    merge-stream "^2.0.0"
-    supports-color "^7.0.0"
-
 jest@26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.0.tgz#546b25a1d8c888569dbbe93cae131748086a4a25"
@@ -8205,6 +8203,13 @@ p-limit@^3.0.2:
   integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
   dependencies:
     p-try "^2.0.0"
+
+p-limit@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -10996,17 +11001,17 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser-webpack-plugin@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz#ec60542db2421f45735c719d2e17dabfbb2e3e42"
-  integrity sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==
+terser-webpack-plugin@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.1.1.tgz#7effadee06f7ecfa093dbbd3e9ab23f5f3ed8673"
+  integrity sha512-5XNNXZiR8YO6X6KhSGXfY0QrGrCRlSwAEjIIrlRQR4W8nP69TaJUlh3bkuac6zzgspiGPfKEHcY295MMVExl5Q==
   dependencies:
-    jest-worker "^26.6.1"
-    p-limit "^3.0.2"
+    jest-worker "^26.6.2"
+    p-limit "^3.1.0"
     schema-utils "^3.0.0"
     serialize-javascript "^5.0.1"
     source-map "^0.6.1"
-    terser "^5.3.8"
+    terser "^5.5.1"
 
 terser@^4.1.2, terser@^4.6.3:
   version "4.6.7"
@@ -11026,10 +11031,19 @@ terser@^4.6.2:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.3.4, terser@^5.3.8:
+terser@^5.3.4:
   version "5.3.8"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.8.tgz#991ae8ba21a3d990579b54aa9af11586197a75dd"
   integrity sha512-zVotuHoIfnYjtlurOouTazciEfL7V38QMAOhGqpXDEg6yT13cF4+fEP9b0rrCEQTn+tT46uxgFsTZzhygk+CzQ==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
+
+terser@^5.5.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.6.1.tgz#a48eeac5300c0a09b36854bf90d9c26fb201973c"
+  integrity sha512-yv9YLFQQ+3ZqgWCUk+pvNJwgUTdlIxUk1WTN+RnaFJe2L7ipG2csPT0ra2XRm7Cs8cxN7QXmK1rFzEwYEQkzXw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.7.2"
@@ -11049,10 +11063,10 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.125.0:
-  version "0.125.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.125.0.tgz#19e922b9dc51ad0b706893aeee888de68e99850a"
-  integrity sha512-qL36qUGsPQ/Ofo/RZdXwHwM7A8wzUSAIyawtjIebJSPvounUQeneSqxI0aBY2iwKpseGy+RUtj3C5f/z4poyXw==
+three@^0.127.0:
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.127.0.tgz#c463f4d41b2c735dcf8e9e51a388815e80cd3791"
+  integrity sha512-wtgrn+mhYUbobxT7QN3GPdu3SRpSBQvwY6uOzLChWS7QE//f7paDU/+wlzbg+ngeIvBBqjBHSRuywTh8A99Jng==
 
 throat@^5.0.0:
   version "5.0.0"
@@ -12090,3 +12104,8 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
Simple PR to upgrade ARnft to 0.8.6. I had this issue https://github.com/webarkit/ARnft/issues/169 was caused by a missed brace https://github.com/kalwalt/ARnft-ES6-react/commit/448aec84dd02d89c577e893e400f1cc9e435e39b but the app works as expected.